### PR TITLE
New Function: Edit & Save Library Files

### DIFF
--- a/src/SPCoder.Core/Plugins/PluginContainer.cs
+++ b/src/SPCoder.Core/Plugins/PluginContainer.cs
@@ -12,6 +12,13 @@ namespace SPCoder.Core.Plugins
 
         public static void Register(BasePlugin plugin)
         {
+            if (Plugins.Any(p => p.Name == plugin.Name))
+            {
+                // remove & re-register
+                var p = Plugins.First(p1 => p1.Name == plugin.Name);
+                Plugins.Remove(p);
+            }
+
             Plugins.Add(plugin);
         }
     }

--- a/src/SPCoder.Core/SPCoder.Core.csproj
+++ b/src/SPCoder.Core/SPCoder.Core.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Plugins\PluginContainer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\BaseConnector.cs" />
+    <Compile Include="Utils\BaseEditedFile.cs" />
     <Compile Include="Utils\Common.cs" />
     <Compile Include="Utils\CrossThreadFormsExtensions.cs" />
     <Compile Include="Utils\Delegates.cs" />

--- a/src/SPCoder.Core/Utils/BaseEditedFile.cs
+++ b/src/SPCoder.Core/Utils/BaseEditedFile.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SPCoder.Utils
+{
+    public abstract class BaseEditedFile
+    {
+        /// <summary>
+        /// Gets or sets the filename
+        /// </summary>
+        public string Filename { get; set; }
+
+
+        /// <summary>
+        /// Gets or sets the full path to the file
+        /// </summary>
+        public string FullFilePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Stream that contains the file contents
+        /// </summary>
+        public Stream Stream { get; set; }
+
+        /// <summary>
+        /// Gets or sets an object that contains the file
+        /// </summary>
+        public object ParentContainer { get; set; }
+
+        /// <summary>
+        /// Override this to control file saving logic
+        /// </summary>
+        /// <param name="overwrite"></param>
+        /// <returns>True if the file was saved, False if not</returns>
+        public virtual bool Save(bool overwrite = false)
+        {
+            return true;
+        }
+    }
+}

--- a/src/SPCoder.SharePoint.Client/SPCoder.SharePoint.Client.csproj
+++ b/src/SPCoder.SharePoint.Client/SPCoder.SharePoint.Client.csproj
@@ -37,6 +37,9 @@
     <Reference Include="EPPlus, Version=4.5.3.2, Culture=neutral, PublicKeyToken=ea159fdaa78159a1, processorArchitecture=MSIL">
       <HintPath>..\packages\EPPlus.4.5.3.2\lib\net40\EPPlus.dll</HintPath>
     </Reference>
+    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Azure.ActiveDirectory.GraphClient, Version=2.1.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Azure.ActiveDirectory.GraphClient.2.1.0\lib\portable-net4+sl5+win+wpa+wp8\Microsoft.Azure.ActiveDirectory.GraphClient.dll</HintPath>
     </Reference>
@@ -208,6 +211,7 @@
     <Compile Include="Utils\Nodes\SiteNode.cs" />
     <Compile Include="Utils\Nodes\WebNode.cs" />
     <Compile Include="Utils\SharePointClientModule.cs" />
+    <Compile Include="Utils\SharePointEditedFile.cs" />
     <Compile Include="Web References\ListsWebService\Reference.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/SPCoder.SharePoint.Client/SPCoder.SharePoint.Client.csproj
+++ b/src/SPCoder.SharePoint.Client/SPCoder.SharePoint.Client.csproj
@@ -212,6 +212,7 @@
     <Compile Include="Utils\Nodes\WebNode.cs" />
     <Compile Include="Utils\SharePointClientModule.cs" />
     <Compile Include="Utils\SharePointEditedFile.cs" />
+    <Compile Include="Utils\WebUtils.cs" />
     <Compile Include="Web References\ListsWebService\Reference.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/src/SPCoder.SharePoint.Client/SPCoder.SharePoint.Client.csproj
+++ b/src/SPCoder.SharePoint.Client/SPCoder.SharePoint.Client.csproj
@@ -202,6 +202,8 @@
     <Compile Include="TokenHelper.cs" />
     <Compile Include="Utils\CSOMConnector.cs" />
     <Compile Include="Utils\Dummy.cs" />
+    <Compile Include="Utils\Nodes\FileNode.cs" />
+    <Compile Include="Utils\Nodes\FolderNode.cs" />
     <Compile Include="Utils\Nodes\ListNode.cs" />
     <Compile Include="Utils\Nodes\SiteNode.cs" />
     <Compile Include="Utils\Nodes\WebNode.cs" />

--- a/src/SPCoder.SharePoint.Client/Utils/CSOMConnector.cs
+++ b/src/SPCoder.SharePoint.Client/Utils/CSOMConnector.cs
@@ -223,48 +223,10 @@ namespace SPCoder.Utils
         }
 
         private BaseNode DoSPList(Microsoft.SharePoint.Client.List list, BaseNode parentNode, BaseNode rootNode)
-        {
-            list.EnsureProperties(l => l.RootFolder);
+        {         
+            list.EnsureProperties(l => l.RootFolder, l => l.BaseType);
 
             return this.DoSPFolder(list.RootFolder, parentNode, rootNode);
-
-            //BaseNode myNode = null;
-            //try
-            //{
-            //    myNode = new FolderNode(list.RootFolder);
-            //    parentNode.Children.Add(myNode);
-
-            //    myNode.ParentNode = parentNode;
-            //    myNode.RootNode = rootNode;
-            //    myNode.NodeConnector = this;
-            //    myNode.LoadedData = true;
-
-            //    list.Context.Load(list.RootFolder.Folders);
-            //    list.Context.ExecuteQueryRetry();
-
-            //    try
-            //    {
-            //        foreach(var subfolder in list.RootFolder.Folders)
-            //        {
-            //            BaseNode childNode = new FolderNode(subfolder);
-            //            myNode.Children.Add(childNode);
-
-            //            childNode.ParentNode = parentNode;
-            //            childNode.RootNode = rootNode;
-            //            childNode.NodeConnector = this;
-            //        }
-            //    }
-            //    catch
-            //    {
-            //        return myNode;
-            //    }
-            //}
-            //catch
-            //{
-            //    return myNode;
-            //}
-
-            //return myNode;
         }
 
         private BaseNode DoSPWeb(Web web, BaseNode parentNode, BaseNode rootNode)

--- a/src/SPCoder.SharePoint.Client/Utils/CSOMConnector.cs
+++ b/src/SPCoder.SharePoint.Client/Utils/CSOMConnector.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.SharePoint.Client;
+﻿using Microsoft.Graph;
+using Microsoft.SharePoint.Client;
 using SPCoder.HelperWindows;
 using SPCoder.Utils.Nodes;
 using System;
@@ -14,8 +15,8 @@ using System.Windows.Forms;
 namespace SPCoder.Utils
 {
     public class CSOMConnector : BaseConnector
-    {        
-        public ClientContext Context { get; set;  }
+    {
+        public ClientContext Context { get; set; }
         public CSOMConnector() : base()
         { }
 
@@ -31,11 +32,11 @@ namespace SPCoder.Utils
             else if (connectorType.Contains(SPCoderConstants.WIN))
                 this.AuthenticationType = SPCoderConstants.WIN;
         }
-        
+
         public CSOMConnector(string username, string password)
         {
             this.Username = username;
-            this.Password = password;        
+            this.Password = password;
         }
 
         public override BaseNode ExpandNode(BaseNode node, bool doIfLoaded = false)
@@ -54,6 +55,33 @@ namespace SPCoder.Utils
                     node = DoSPWeb((Web)node.SPObject, node.ParentNode, node.RootNode);
                 }
             }
+
+            if (node is ListNode)
+            {
+                if (!doIfLoaded)
+                {
+                    if (node.ParentNode.Children != null && node.ParentNode.Children.Contains(node))
+                    {
+                        node.ParentNode.Children.Remove(node);
+                    }
+
+                    node = DoSPList((Microsoft.SharePoint.Client.List)node.SPObject, node.ParentNode, node.RootNode);
+                }
+            }
+
+            if (node is FolderNode)
+            {
+                if (!doIfLoaded)
+                {
+                    if (node.ParentNode.Children != null && node.ParentNode.Children.Contains(node))
+                    {
+                        node.ParentNode.Children.Remove(node);
+                    }
+
+                    node = DoSPFolder((Microsoft.SharePoint.Client.Folder)node.SPObject, node.ParentNode, node.RootNode);
+                }
+            }
+
             return node;
         }
         public override BaseNode GetSPStructure(string siteUrl)
@@ -93,7 +121,7 @@ namespace SPCoder.Utils
                 }
             }
 
-            
+
             if (this.AuthenticationType == SPCoderConstants.O365)
             {
                 Context = new ClientContext(siteUrl);
@@ -101,13 +129,13 @@ namespace SPCoder.Utils
                 foreach (char c in Password.ToCharArray()) pass.AppendChar(c);
                 Context.Credentials = new SharePointOnlineCredentials(Username, pass);
             }
-            else if(this.AuthenticationType == SPCoderConstants.O365_APP)
+            else if (this.AuthenticationType == SPCoderConstants.O365_APP)
             {
                 //Get the realm for the URL
                 string realm = SPCoder.SharePoint.Client.TokenHelper.GetRealmFromTargetUrl(new Uri(siteUrl));
                 string accessToken = SPCoder.SharePoint.Client.TokenHelper.GetAppOnlyAccessToken(SPCoder.SharePoint.Client.TokenHelper.SharePointPrincipal, new Uri(siteUrl).Authority, realm).AccessToken;
                 Context = SPCoder.SharePoint.Client.TokenHelper.GetClientContextWithAccessToken(siteUrl, accessToken);
-                
+
             }
             else if (this.AuthenticationType == SPCoderConstants.FBA)
             {
@@ -128,7 +156,7 @@ namespace SPCoder.Utils
 
         public override BaseNode GenerateRootNode()
         {
-            Site site = Context.Site;
+            Microsoft.SharePoint.Client.Site site = Context.Site;
             Context.Load(site);
             Context.ExecuteQuery();
             BaseNode rootNode = new SiteNode(site);
@@ -139,6 +167,104 @@ namespace SPCoder.Utils
             rootNode.LoadedData = true;
             DoSPWeb(site.RootWeb, rootNode, rootNode);
             return rootNode;
+        }
+
+        private BaseNode DoSPFolder(Microsoft.SharePoint.Client.Folder folder, BaseNode parentNode, BaseNode rootNode)
+        {
+            BaseNode myNode = null;
+            folder.EnsureProperties(f => f.Folders, f => f.Files, f => f.Name, f => f.ServerRelativeUrl);
+
+            try
+            {
+                myNode = new FolderNode(folder);
+                parentNode.Children.Add(myNode);
+
+                myNode.ParentNode = parentNode;
+                myNode.RootNode = rootNode;
+                myNode.NodeConnector = this;
+                myNode.LoadedData = true;
+
+                folder.Context.Load(folder.Folders);
+                folder.Context.ExecuteQueryRetry();
+
+                try
+                {
+                    foreach (var subfolder in folder.Folders.OrderBy(f => f.Name))
+                    {
+                        BaseNode childNode = new FolderNode(subfolder);
+                        myNode.Children.Add(childNode);
+
+                        childNode.ParentNode = parentNode;
+                        childNode.RootNode = rootNode;
+                        childNode.NodeConnector = this;
+                    }
+
+                    foreach(var file in folder.Files.OrderBy(f => f.Name))
+                    {
+                        BaseNode fileNode = new FileNode(file);
+                        myNode.Children.Add(fileNode);
+
+                        fileNode.ParentNode = parentNode;
+                        fileNode.RootNode = rootNode;
+                        fileNode.NodeConnector = this;
+                    }
+                }
+                catch
+                {
+                    return myNode;
+                }
+            }
+            catch
+            {
+                return myNode;
+            }
+
+            return myNode;
+        }
+
+        private BaseNode DoSPList(Microsoft.SharePoint.Client.List list, BaseNode parentNode, BaseNode rootNode)
+        {
+            list.EnsureProperties(l => l.RootFolder);
+
+            return this.DoSPFolder(list.RootFolder, parentNode, rootNode);
+
+            //BaseNode myNode = null;
+            //try
+            //{
+            //    myNode = new FolderNode(list.RootFolder);
+            //    parentNode.Children.Add(myNode);
+
+            //    myNode.ParentNode = parentNode;
+            //    myNode.RootNode = rootNode;
+            //    myNode.NodeConnector = this;
+            //    myNode.LoadedData = true;
+
+            //    list.Context.Load(list.RootFolder.Folders);
+            //    list.Context.ExecuteQueryRetry();
+
+            //    try
+            //    {
+            //        foreach(var subfolder in list.RootFolder.Folders)
+            //        {
+            //            BaseNode childNode = new FolderNode(subfolder);
+            //            myNode.Children.Add(childNode);
+
+            //            childNode.ParentNode = parentNode;
+            //            childNode.RootNode = rootNode;
+            //            childNode.NodeConnector = this;
+            //        }
+            //    }
+            //    catch
+            //    {
+            //        return myNode;
+            //    }
+            //}
+            //catch
+            //{
+            //    return myNode;
+            //}
+
+            //return myNode;
         }
 
         private BaseNode DoSPWeb(Web web, BaseNode parentNode, BaseNode rootNode)
@@ -154,7 +280,7 @@ namespace SPCoder.Utils
                 myNode.LoadedData = true;
                 web.Context.Load(web.Webs);
                 web.Context.Load(web.Lists);
-                
+
                 web.Context.ExecuteQuery();
                 try
                 {
@@ -173,8 +299,8 @@ namespace SPCoder.Utils
                 {
                     return myNode;
                 }
-                
-                foreach (List list in web.Lists)
+
+                foreach (Microsoft.SharePoint.Client.List list in web.Lists)
                 {
                     BaseNode myListNode = new ListNode(list);
                     myNode.Children.Add(myListNode);

--- a/src/SPCoder.SharePoint.Client/Utils/Nodes/ListNode.cs
+++ b/src/SPCoder.SharePoint.Client/Utils/Nodes/ListNode.cs
@@ -2,6 +2,7 @@
 using SPCoder.Core.Plugins;
 using SPCoder.Core.Utils;
 using SPCoder.Core.Utils.Nodes;
+using SPCoder.SharePoint.Client.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
@@ -59,9 +60,10 @@ namespace SPCoder.Utils.Nodes
                     if (realObj != null)
                     {
                         Web objWeb = (Web)base.ParentNode.SPObject;
+                        List list = (List)realObj;
+                        list.EnsureProperties(l => l.DefaultView.ServerRelativeUrl);
 
-                        string url = objWeb.Url.Replace(objWeb.ServerRelativeUrl, ((List)realObj).DefaultView.ServerRelativeUrl);
-                        return url;
+                        return WebUtils.MakeAbsoluteUrl(objWeb, list.DefaultView.ServerRelativeUrl);
                     }
                     else
                         return null;
@@ -70,8 +72,10 @@ namespace SPCoder.Utils.Nodes
                     {
                         Web objWeb = (Web)base.ParentNode.SPObject;
 
-                        string url = objWeb.Url.Replace(objWeb.ServerRelativeUrl, ((List)realObj).DefaultView.ServerRelativeUrl);
-                        return url;
+                        List list = (List)realObj;
+                        list.EnsureProperties(l => l.DefaultView.ServerRelativeUrl);
+
+                        return WebUtils.MakeAbsoluteUrl(objWeb, list.DefaultView.ServerRelativeUrl);
                     }
                     else
                         return null;

--- a/src/SPCoder.SharePoint.Client/Utils/SharePointEditedFile.cs
+++ b/src/SPCoder.SharePoint.Client/Utils/SharePointEditedFile.cs
@@ -1,0 +1,75 @@
+﻿using SPCoder.Core.Utils;
+using SPCoder.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.SharePoint.Client;
+
+namespace SPCoder.SharePoint.Client.Utils
+{
+    public class SharePointEditedFile : BaseEditedFile
+    {
+        public override bool Save(bool overwrite = false)
+        {
+            if (!(this.ParentContainer is Folder))
+            {
+                SPCoderLogging.Logger.Info("ParentContainer is not an SP Folder. Bailing out...");
+            }
+
+            FileCreationInformation fileCreation = new FileCreationInformation();
+            fileCreation.Url = this.Filename;
+            fileCreation.ContentStream = this.Stream;
+            fileCreation.Overwrite = overwrite;
+
+
+            Folder parentFolder = (Folder)this.ParentContainer;
+            ClientContext ctx = parentFolder.Context as ClientContext;
+
+            try
+            {
+                // If it's checked in, check it out then re-publish
+                // If it's checked out to us, save it then leave it checked out
+                File existingFile = parentFolder.GetFile(this.Filename);
+                existingFile.EnsureProperties(f => f.CheckedOutByUser);
+
+                bool wasCheckedOut = existingFile.CheckedOutByUser.ServerObjectIsNull == false;
+                if (wasCheckedOut)
+                {
+                    // Make sure it's the current user that has the file checked out
+                    User me = ctx.Web.CurrentUser;
+                    me.EnsureProperties(m => m.Id);
+
+                    if (me.Id != existingFile.CheckedOutByUser.Id)
+                    {
+                        SPCoderLogging.Logger.Error($"File is already checked out to: {existingFile.CheckedOutByUser.Title}");
+                        return false;
+                    }
+                }
+                else
+                {
+                    existingFile.CheckOut();
+                }
+
+                File newFile = parentFolder.Files.Add(fileCreation);
+                ctx.Load(newFile);
+                
+                if (!wasCheckedOut)
+                {
+                    // Todo - allow setting what type of checkin to save with
+                    newFile.CheckIn("Checked In by SPCoder", CheckinType.MajorCheckIn);
+                }
+
+                ctx.ExecuteQueryRetry();
+            }
+            catch (Exception ex)
+            {
+                SPCoderLogging.Logger.Error($"Failed to save file: {ex.ToString()}");
+                throw;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/SPCoder.SharePoint.Client/Utils/WebUtils.cs
+++ b/src/SPCoder.SharePoint.Client/Utils/WebUtils.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.SharePoint.Client;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SPCoder.SharePoint.Client.Utils
+{
+    internal static class WebUtils
+    {
+        public static string MakeAbsoluteUrl(Web web, string serverRelativeUrl)
+        {
+            // e.g. 
+            // Web: 
+            // https://tenant.sharepoint.com/sites/foo/bar
+            // serverRelative:
+            // /sites/foo/bar/documents/sample.txt
+            web.EnsureProperties(w => w.Url);
+
+            Uri webUri = new Uri(web.Url);
+            string tenantStub = $"{webUri.Scheme}://{webUri.Authority}";
+
+            return $"{tenantStub}{serverRelativeUrl}";
+        }
+    }
+}

--- a/src/SPCoder.SharePoint.Client/packages.config
+++ b/src/SPCoder.SharePoint.Client/packages.config
@@ -3,6 +3,7 @@
   <package id="AppForSharePointOnlineWebToolkit" version="3.1.5" targetFramework="net45" />
   <package id="Camlex.Client.dll" version="4.0.0" targetFramework="net47" />
   <package id="EPPlus" version="4.5.3.2" targetFramework="net47" />
+  <package id="log4net" version="2.0.8" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Azure.ActiveDirectory.GraphClient" version="2.1.0" targetFramework="net45" />

--- a/src/SPCoder.WinApp/SPCoder.WinApp.2016.csproj
+++ b/src/SPCoder.WinApp/SPCoder.WinApp.2016.csproj
@@ -303,6 +303,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <None Include="Scripts\CSharp\Plugins\SPSharePointFileEditor.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <Compile Include="Utils\CryptoHelper.cs" />
     <Compile Include="Utils\ISPCoderForm.cs" />
     <Compile Include="Utils\SPCoderSettings.cs" />
@@ -572,6 +575,22 @@
     <ProjectReference Include="..\SPCoder.Core\SPCoder.Core.csproj">
       <Project>{4c10cebc-afa4-425a-a87c-ca04c8bc2d88}</Project>
       <Name>SPCoder.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SPCoder.FileSystem\SPCoder.FileSystem.csproj">
+      <Project>{63FDF3F5-BB6D-4459-9F83-C64DE73B4484}</Project>
+      <Name>SPCoder.FileSystem</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SPCoder.Github\SPCoder.Github.csproj">
+      <Project>{978149EA-1411-494D-8C27-CFF1C40F1BD6}</Project>
+      <Name>SPCoder.Github</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SPCoder.SharePoint.Client\SPCoder.SharePoint.Client.csproj">
+      <Project>{255A1D98-A7CC-451A-AC11-A4CC9F174BBD}</Project>
+      <Name>SPCoder.SharePoint.Client</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SPCoder.Web\SPCoder.Web.csproj">
+      <Project>{9FFBAFCB-2892-4F84-9DD1-67BE7CC67BB0}</Project>
+      <Name>SPCoder.Web</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SPCoder.WinApp/SPCoderForm.cs
+++ b/src/SPCoder.WinApp/SPCoderForm.cs
@@ -915,7 +915,6 @@ namespace SPCoder
             }
 
             newCode.EditedFile = editedFile;
-            newCode.Source = null;
             newCode.Title = editedFile.Filename;
             newCode.FullFileName = editedFile.Filename;
             newCode.FileName = editedFile.Filename;

--- a/src/SPCoder.WinApp/SPCoderForm.cs
+++ b/src/SPCoder.WinApp/SPCoderForm.cs
@@ -888,6 +888,42 @@ namespace SPCoder
             codeWindows.Add(newCode);
         }
         
+        public void GeneratedEditedFileTab(BaseEditedFile editedFile)
+        {
+            if (this.InvokeRequired)
+            {
+                this.BeginInvoke((MethodInvoker)delegate ()
+                {
+                    GeneratedEditedFileTabPrivate(editedFile);
+                });
+            }
+            else
+            {
+                GeneratedEditedFileTabPrivate(editedFile);
+            }
+        }
+
+        private void GeneratedEditedFileTabPrivate(BaseEditedFile editedFile)
+        {
+            CSharpCode newCode = new CSharpCode();
+            newCode.Fctb.ContextMenuStrip = cmMain;
+            newCode.Fctb.Language = GetLanguageFromFileName(editedFile.Filename);
+
+            using (StreamReader reader = new StreamReader(editedFile.Stream))
+            {
+                newCode.Source = reader.ReadToEnd();
+            }
+
+            newCode.EditedFile = editedFile;
+            newCode.Source = null;
+            newCode.Title = editedFile.Filename;
+            newCode.FullFileName = editedFile.Filename;
+            newCode.FileName = editedFile.Filename;
+
+            newCode.Show(dockPanel, DockState.Document);
+            codeWindows.Add(newCode);
+        }
+
         private Language GetLanguageFromFileName(string fileName)
         {
             Language lang = Language.CSharp;

--- a/src/SPCoder.WinApp/Scripts/CSharp/Plugins/SPSharePointFileEditor.csx
+++ b/src/SPCoder.WinApp/Scripts/CSharp/Plugins/SPSharePointFileEditor.csx
@@ -1,0 +1,62 @@
+﻿using Microsoft.SharePoint.Client;
+using File = Microsoft.SharePoint.Client.File;
+
+public class SPFileDetails
+{
+    public string FileName { get; set; }
+    public string FileContents { get; set; }
+    public string FileExtension { get; set; }
+}
+
+public class SPSharePointFileEditor : BasePlugin
+{
+    public SPSharePointFileEditor()
+    {
+        this.TargetType = typeof(Microsoft.SharePoint.Client.File);
+        this.Name = "Edit File";
+    }
+
+    public override void Execute(Object target)
+    {
+        File file = (File)target;
+        var ctx = file.Context as ClientContext;
+        var stream = file.OpenBinaryStream();
+
+        ctx.Load(file);
+        ctx.ExecuteQuery();
+
+        string fileContent = string.Empty;
+
+        using (StreamReader reader = new StreamReader(stream.Value))
+        {
+            fileContent = reader.ReadToEnd();
+        }
+
+        Console.WriteLine("Read file 2");
+
+        var fileDetails = new SPFileDetails
+        {
+            FileName = file.Name,
+            FileContents = fileContent,
+            FileExtension = System.IO.Path.GetExtension(file.Name)
+        };
+
+        Result = fileDetails;
+        ExecuteCallback(fileDetails);
+    }
+}
+
+public void GenerateNewSourceTabSPFile(object item)
+{
+    if (item is SPFileDetails)
+    {
+        var fileDetails = (SPFileDetails)item;
+        main.GenerateNewSourceTab(fileDetails.FileName, fileDetails.FileContents, null, fileDetails.FileExtension);
+    }
+}
+
+SPSharePointFileEditor spEditFile = new SPSharePointFileEditor();
+spEditFile.Callback += GenerateNewSourceTabSPFile;
+PluginContainer.Register(spEditFile);
+
+logger.LogInfo("Registered plugin SPSharePointFileEditor");

--- a/src/SPCoder.WinApp/Windows/ExplorerView.cs
+++ b/src/SPCoder.WinApp/Windows/ExplorerView.cs
@@ -14,6 +14,10 @@ using WeifenLuo.WinFormsUI.Docking;
 using SPCoder.Properties;
 using SPCoder.Core.Utils.Nodes;
 using System.Diagnostics;
+using SPCoder.SharePoint.Client.Utils;
+using SPCoder.Web.Utils;
+using SPCoder.FileSystem.Utils;
+using SPCoder.Github.Utils;
 
 namespace SPCoder.Windows
 {
@@ -56,10 +60,10 @@ namespace SPCoder.Windows
                 //Workaround for .NET framework Bug related to MEF
                 SPCoderForm.MainForm.Modules = new List<ModuleDescription>();
                 //SPCoderForm.MainForm.Modules.Add(new FBModule());
-                //SPCoderForm.MainForm.Modules.Add(new GithubModule());
-                //SPCoderForm.MainForm.Modules.Add(new FSModule());
-                //SPCoderForm.MainForm.Modules.Add(new WebModule());                
-                //SPCoderForm.MainForm.Modules.Add(new SharePointClientModule());                               
+                SPCoderForm.MainForm.Modules.Add(new GithubModule());
+                SPCoderForm.MainForm.Modules.Add(new FSModule());
+                SPCoderForm.MainForm.Modules.Add(new WebModule());                
+                SPCoderForm.MainForm.Modules.Add(new SharePointClientModule());                               
             }
             
             foreach (ModuleDescription module in SPCoderForm.MainForm.Modules)
@@ -751,7 +755,15 @@ namespace SPCoder.Windows
                         object valueObject = action.Node.ExecuteAction(action);
                         if (valueObject != null)
                         {
-                            action.Plugin.Execute(valueObject);
+                            try
+                            {
+                                action.Plugin.Execute(valueObject);
+                            }
+                            catch(Exception ex)
+                            {
+                                SPCoderForm.MainForm.LogException(ex);
+                                //SPCoderLogging.Logger.Error($"Error in Plugin: {ex.ToString()}");
+                            }
                         }
                         break;
                 }

--- a/src/SPCoder.WinApp/app.config
+++ b/src/SPCoder.WinApp/app.config
@@ -69,6 +69,26 @@
         <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.8.4.0" newVersion="5.8.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
- Enables browsing of folder hierarchy of Document Libraries within the Explorer View of SharePoint sites
- Allows opening of files in Libraries in a new instance of the code editor
- Allows saving of files back into SharePoint (currently preserves checkout status - if the file was checked in, it's checked out, saved, then checked back in. If you already had it checked it, it leaves it checked out. If someone else had it checked out, it stays checked out)
- Allows "Saving a copy" of a file, so it can be saved to file system (via File Menu)